### PR TITLE
Add word-by-word markdown demo

### DIFF
--- a/Examples/Demo/Demo/ContentView.swift
+++ b/Examples/Demo/Demo/ContentView.swift
@@ -93,6 +93,13 @@ struct ContentView: View {
           } label: {
             Label("Lazy Loading", systemImage: "scroll")
           }
+          NavigationLink {
+            WordByWordView()
+              .navigationTitle("Word by Word")
+              .navigationBarTitleDisplayMode(.inline)
+          } label: {
+            Label("Word by Word", systemImage: "text.word.wrap")
+          }
         }
       }
       .navigationTitle("MarkdownUI")

--- a/Examples/Demo/Demo/WordByWordView.swift
+++ b/Examples/Demo/Demo/WordByWordView.swift
@@ -1,0 +1,48 @@
+import MarkdownUI
+import SwiftUI
+
+private enum Constants {
+  static let delay: UInt64 = 300_000_000
+  static let zero = 0
+  static let one = 1
+  static let sample = """
+    # Word by Word
+    This demo renders markdown content word by word using async/await.
+    """
+}
+
+struct WordByWordView: View {
+  var body: some View {
+    DemoView {
+      WordByWordMarkdown(Constants.sample)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+}
+
+private struct WordByWordMarkdown: View {
+  private let words: [Substring]
+  @State private var shown = Constants.zero
+
+  init(_ markdown: String) {
+    let attr = (try? AttributedString(markdown: markdown)) ?? AttributedString()
+    let plain = String(attr.characters)
+    words = plain.split { $0.isWhitespace }
+  }
+
+  var body: some View {
+    Text(words.prefix(shown).joined(separator: " "))
+      .task {
+        for i in Constants.one...words.count {
+          await Task.sleep(nanoseconds: Constants.delay)
+          shown = i
+        }
+      }
+  }
+}
+
+struct WordByWordView_Previews: PreviewProvider {
+  static var previews: some View {
+    WordByWordView()
+  }
+}

--- a/Examples/Demo/Demo/WordByWordView.swift
+++ b/Examples/Demo/Demo/WordByWordView.swift
@@ -14,30 +14,110 @@ private enum Constants {
 struct WordByWordView: View {
   var body: some View {
     DemoView {
-      WordByWordMarkdown(Constants.sample)
+      ProgressiveMarkdown(Constants.sample)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
   }
 }
 
-private struct WordByWordMarkdown: View {
-  private let words: [Substring]
+private struct ProgressiveMarkdown: View {
+  private let chunks: [MarkdownContent]
   @State private var shown = Constants.zero
 
   init(_ markdown: String) {
-    let attr = (try? AttributedString(markdown: markdown)) ?? AttributedString()
-    let plain = String(attr.characters)
-    words = plain.split { $0.isWhitespace }
+    let blocks = MarkdownContent(markdown).blocks
+    chunks = Self.makeChunks(from: blocks)
   }
 
   var body: some View {
-    Text(words.prefix(shown).joined(separator: " "))
-      .task {
-        for i in Constants.one...words.count {
-          await Task.sleep(nanoseconds: Constants.delay)
-          shown = i
-        }
+    VStack(alignment: .leading, spacing: .zero) {
+      ForEach(Constants.zero..<shown, id: \.self) { i in
+        Markdown(chunks[i])
       }
+    }
+    .task {
+      for i in Constants.one...chunks.count {
+        await Task.sleep(nanoseconds: Constants.delay)
+        shown = i
+      }
+    }
+  }
+
+  private static func makeChunks(from blocks: [BlockNode]) -> [MarkdownContent] {
+    var result: [MarkdownContent] = []
+    for block in blocks {
+      switch block {
+      case .paragraph(let inlines):
+        var partial: [InlineNode] = []
+        for piece in split(inlines) {
+          partial += piece
+          result.append(MarkdownContent(block: .paragraph(content: partial)))
+        }
+      default:
+        result.append(MarkdownContent(block: block))
+      }
+    }
+    return result
+  }
+
+  private static func split(_ inlines: [InlineNode]) -> [[InlineNode]] {
+    var pieces: [[InlineNode]] = []
+    var current: [InlineNode] = []
+
+    func flush() {
+      guard !current.isEmpty else { return }
+      pieces.append(current)
+      current = []
+    }
+
+    for node in inlines {
+      switch node {
+      case .text(let str):
+        var word = ""
+        for ch in str {
+          if ch.isWhitespace {
+            if !word.isEmpty {
+              current.append(.text(word))
+              word = ""
+            }
+            flush()
+          } else {
+            word.append(ch)
+          }
+        }
+        if !word.isEmpty { current.append(.text(word)) }
+
+      case .emphasis(let children):
+        for w in split(children) {
+          current.append(.emphasis(children: w))
+          flush()
+        }
+
+      case .strong(let children):
+        for w in split(children) {
+          current.append(.strong(children: w))
+          flush()
+        }
+
+      case .strikethrough(let children):
+        for w in split(children) {
+          current.append(.strikethrough(children: w))
+          flush()
+        }
+
+      case .link(let dst, let children):
+        for w in split(children) {
+          current.append(.link(destination: dst, children: w))
+          flush()
+        }
+
+      case .image, .code, .html, .softBreak, .lineBreak:
+        current.append(node)
+        flush()
+      }
+    }
+    flush()
+    return pieces
   }
 }
 


### PR DESCRIPTION
## Summary
- add example view that reveals markdown text word by word using async/await
- link new demo in the sample app's navigation

## Testing
- `swift test` *(fails: unable to clone repository https://github.com/swiftlang/swift-cmark/)*

------
https://chatgpt.com/codex/tasks/task_e_68bec1775ad4832eaeb296e50b6df838